### PR TITLE
Add tree reachability (clipping) check to woodcutting logic

### DIFF
--- a/2006Scape Server/src/main/java/com/rs2/game/content/skills/woodcutting/Woodcutting.java
+++ b/2006Scape Server/src/main/java/com/rs2/game/content/skills/woodcutting/Woodcutting.java
@@ -254,9 +254,6 @@ public class Woodcutting {
 				treeclipping,
 				clipping);
 
-		p.getPacketSender().sendMessage("Clipping: " + clipping);
-		p.getPacketSender().sendMessage("Reached: " + reached);
-
 		if (!reached) {
 			p.getPacketSender().sendMessage("Can't reach the tree from here.");
 		}

--- a/2006Scape Server/src/main/java/com/rs2/game/content/skills/woodcutting/Woodcutting.java
+++ b/2006Scape Server/src/main/java/com/rs2/game/content/skills/woodcutting/Woodcutting.java
@@ -10,9 +10,11 @@ import com.rs2.game.content.randomevents.TreeSpirit;
 import com.rs2.game.content.skills.SkillHandler;
 import com.rs2.game.items.DeprecatedItems;
 import com.rs2.game.objects.Object;
+import com.rs2.game.objects.Objects;
 import com.rs2.game.players.Player;
 import com.rs2.game.players.PlayerHandler;
 import com.rs2.util.Misc;
+import com.rs2.world.clip.Region;
 
 public class Woodcutting {
 	
@@ -227,6 +229,41 @@ public class Woodcutting {
 		return false;
 	}
 
+	private static boolean canReachTree(Player p, int treeX, int treeY, int id) {
+		int pointerOffsetX = p.getMapRegionX();
+		int pointerOffsetY = p.getMapRegionY();
+
+		int treeRelX = treeX - (pointerOffsetX << 3);
+		int treeRelY = treeY - (pointerOffsetY << 3);
+		int playerOffsetX = p.getX() - (pointerOffsetX << 3);
+		int playerOffsetY = p.getY() - (pointerOffsetY << 3);
+
+		Region region = Region.getRegion(p.getX(), p.getY());
+		int clipping = region.getClipping(p.getX(), p.getY(), p.heightLevel);
+
+		Objects tree = region.GetObjectAt(treeX, treeY, id);
+
+		int treeclipping = region.getClipping(treeX, treeY, p.heightLevel);
+
+		boolean reached = Region.reachedObject(playerOffsetX,
+				playerOffsetY,
+				treeRelX,
+				treeRelY,
+				tree.getObjectSize()[0],
+				tree.getObjectSize()[1],
+				treeclipping,
+				clipping);
+
+		p.getPacketSender().sendMessage("Clipping: " + clipping);
+		p.getPacketSender().sendMessage("Reached: " + reached);
+
+		if (!reached) {
+			p.getPacketSender().sendMessage("Can't reach the tree from here.");
+		}
+
+		return reached;
+	}
+
 	public static void startWoodcutting(final Player p, final int objectId, final int x, final int y, final int type) {
 		CycleEventHandler.getSingleton().stopEvents(p, "WoodcuttingEvent".hashCode());
 		if (p.isWoodcutting || p.isFletching || p.isFiremaking || p.playerIsFletching) {
@@ -244,6 +281,9 @@ public class Woodcutting {
 		p.woodcuttingAxe = -1;
 		treeData tree = treeData.getTree(objectId);
 		p.turnPlayerTo(x, y);
+
+		if (!canReachTree(p, x, y, objectId)) return;
+
 		if (tree.getLevelReq() > wcLevel) {
 			p.getPacketSender().sendMessage("You need a Woodcutting level of " + tree.getLevelReq() + " to cut this tree.");
 			return;

--- a/2006Scape Server/src/main/java/com/rs2/world/clip/Region.java
+++ b/2006Scape Server/src/main/java/com/rs2/world/clip/Region.java
@@ -649,6 +649,17 @@ public class Region {
 		}
 	}
 
+	public Objects GetObjectAt(int x, int y, int id)
+	{
+		for (Objects o : realObjects) {
+			if (o.objectX == x && o.objectY == y && o.objectId == id) {
+				return o;
+			}
+		}
+
+		return null;
+	}
+
 	public static int getClipping(int x, int y, int height) {
 		if (height > 3) {
 			height = 0; //this doesn't seem good
@@ -714,6 +725,35 @@ public class Region {
 		} catch (Exception e) {
 			return true;
 		}
+	}
+
+	public static boolean reachedObject(int startX, int startY, int endX, int endY, int endDistanceX, int endDistanceY,
+										int surroundings, int clipping)
+	{
+		int endX2 = (endX + endDistanceX) - 1;
+		int endY2 = (endY + endDistanceY) - 1;
+
+		if (startX >= endX && startX <= endX2 && startY >= endY && startY <= endY2)
+		{
+			return true;
+		}
+
+		if (startX == endX - 1 && startY >= endY && startY <= endY2
+				&& (clipping & 8) == 0 && (surroundings & 8) == 0)
+		{
+			return true;
+		}
+
+		if (startX == endX2 + 1 && startY >= endY && startY <= endY2
+				&& (clipping & 0x80) == 0 && (surroundings & 2) == 0)
+		{
+			return true;
+		}
+
+		return startY == endY - 1 && startX >= endX && startX <= endX2
+				&& (clipping & 2) == 0 && (surroundings & 4) == 0
+				|| startY == endY2 + 1 && startX >= endX && startX <= endX2
+				&& (clipping & 0x20) == 0 && (surroundings & 1) == 0;
 	}
 
 }


### PR DESCRIPTION
### Description

This pull request introduces a `canReachTree` method to the woodcutting logic, ensuring trees are accessible before woodcutting begins. It includes:
- A new function in Region called "GetObjectAt".
- A new function in Region called "reachedObject".

This update aims to improve gameplay mechanics by preventing unreachable tree interactions.

### Checklist

- [x] Code compiles without errors.
- [x] Tested Normal, Oak, Willow, Maple, Yew & Magic trees at various locations.

### Additional Notes

N/A